### PR TITLE
fixed paper sosym2013 doi link

### DIFF
--- a/lucasccordeiro/index.html
+++ b/lucasccordeiro/index.html
@@ -172,7 +172,7 @@
 					<br>
 					<b>2015</b>
 					<br><br>
-					<p>18. Morse, J, Cordeiro, L. C., Nicole, D., Fischer, B. <b><a href="https://ssvlab.github.io/lucasccordeiro/papers/sosym2013.pdf">Model Checking LTL Properties over C Programs with Bounded Traces</a></b>. In Journal of Software and Systems Modeling, Springer, v. 13, n. 1, pp. 65-81, 2015 via <a href="dx.doi.org/10.1007/s10270-013-0366-0">DOI</a>.</p>
+					<p>18. Morse, J, Cordeiro, L. C., Nicole, D., Fischer, B. <b><a href="https://ssvlab.github.io/lucasccordeiro/papers/sosym2013.pdf">Model Checking LTL Properties over C Programs with Bounded Traces</a></b>. In Journal of Software and Systems Modeling, Springer, v. 13, n. 1, pp. 65-81, 2015 via <a href="http://dx.doi.org/10.1007/s10270-013-0366-0">DOI</a>.</p>
 					<!-- -->
 					<br>
 					<b>2014</b>


### PR DESCRIPTION
The hyperlink was giving error 404 since it was trying to redirect to https://ssvlab.github.io/lucasccordeiro/dx.doi.org/10.1007/s10270-013-0366-0

Added http:// to redirect properly